### PR TITLE
Add version specifier to travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: go
 
+go:
+    - 1.1
+    - tip

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Based on the [wikipedia paper][wiki] and the [RFC 3986 document][rfc].
 
 [![build status](https://secure.travis-ci.org/PuerkitoBio/purell.png)](http://travis-ci.org/PuerkitoBio/purell)
 
-Note that at this moment, travis still uses Go1.0.3, and the Go stdlibs changed some behaviour between 1.0.3 and Go1.1. My tests have been updated to pass with Go1.1, so until Travis updates to the latest release of Go, it will display **fail**...
-
 ## Install
 
 `go get github.com/PuerkitoBio/purell`


### PR DESCRIPTION
Also remove the warning in the README file, as the build status should
be fixed now.

Sorry, I know this is a particularly silly PR, but it's always unnerving for
me to see a failed CI icon. I tested my fork on Travis and all is well :+1:
