### PR TITLE
This patch allows FlagRemoveDotSegments to work with relative links --

### DIFF
--- a/purell.go
+++ b/purell.go
@@ -231,7 +231,7 @@ func removeDotSegments(u *url.URL) {
 		}
 		// Special case if host does not end with / and new path does not begin with /
 		u.Path = strings.Join(dotFree, "/")
-		if !strings.HasSuffix(u.Host, "/") && !strings.HasPrefix(u.Path, "/") {
+		if u.Host != "" && !strings.HasSuffix(u.Host, "/") && !strings.HasPrefix(u.Path, "/") {
 			u.Path = "/" + u.Path
 		}
 		// Special case if the last segment was a dot, make sure the path ends with a slash

--- a/purell_test.go
+++ b/purell_test.go
@@ -653,6 +653,28 @@ var (
 			"http://test.example/foo/bar/",
 			false,
 		},
+		&testCase{
+			"Relative-1",
+			"./../foo",
+			FlagsSafe | FlagRemoveDotSegments | FlagRemoveDuplicateSlashes,
+			"foo",
+			false,
+		},
+		&testCase{
+			"Relative-2",
+			"./foo/bar/../baz/../bang/..",
+			FlagsSafe | FlagRemoveDotSegments | FlagRemoveDuplicateSlashes,
+			"foo/",
+			false,
+		},
+		&testCase{
+			"Relative-3",
+			"foo///bar//",
+			FlagsSafe | FlagRemoveDotSegments | FlagRemoveDuplicateSlashes,
+			"foo/bar/",
+			false,
+		},
+
 		/*&testCase{
 			"UrlNorm-5",
 			"http://ja.wikipedia.org/wiki/%E3%82%AD%E3%83%A3%E3%82%BF%E3%83%94%E3%83%A9%E3%83%BC%E3%82%B8%E3%83%A3%E3%83%91%E3%83%B3",


### PR DESCRIPTION
i.e. URL's that have the Host field set to the empty string.
Just to be clear, relative links will be stored in URL's,
typically, if the user expects to later call URL.ResolveReference
to create a full URL. That seems to be a relatively common use-case.