### PR TITLE
Add FlagRemoveQuery (strips entire query part)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ const (
 	FlagRemoveUnnecessaryHostDots // http://.host../path -> http://host/path
 	FlagRemoveEmptyPortSeparator  // http://host:/path -> http://host/path
 
+	FlagRemoveQuery // http://host/path?c=3&b=2&a=1&b=1 -> http://host/path
+
 	// Convenience set of safe normalizations
 	FlagsSafe NormalizationFlags = FlagLowercaseHost | FlagLowercaseScheme | FlagUppercaseEscapes | FlagDecodeUnnecessaryEscapes | FlagEncodeNecessaryEscapes | FlagRemoveDefaultPort | FlagRemoveEmptyQuerySeparator
 

--- a/purell.go
+++ b/purell.go
@@ -52,6 +52,8 @@ const (
 	FlagRemoveUnnecessaryHostDots // http://.host../path -> http://host/path
 	FlagRemoveEmptyPortSeparator  // http://host:/path -> http://host/path
 
+	FlagRemoveQuery // http://host/path?c=3&b=2&a=1&b=1 -> http://host/path
+
 	// Convenience set of safe normalizations
 	FlagsSafe NormalizationFlags = FlagLowercaseHost | FlagLowercaseScheme | FlagUppercaseEscapes | FlagDecodeUnnecessaryEscapes | FlagEncodeNecessaryEscapes | FlagRemoveDefaultPort | FlagRemoveEmptyQuerySeparator
 
@@ -102,6 +104,7 @@ var flagsOrder = []NormalizationFlags{
 	FlagRemoveDuplicateSlashes,
 	FlagRemoveWWW,
 	FlagAddWWW,
+	FlagRemoveQuery,
 	FlagSortQuery,
 	FlagDecodeDWORDHost,
 	FlagDecodeOctalHost,
@@ -124,6 +127,7 @@ var flags = map[NormalizationFlags]func(*url.URL){
 	FlagRemoveDuplicateSlashes:    removeDuplicateSlashes,
 	FlagRemoveWWW:                 removeWWW,
 	FlagAddWWW:                    addWWW,
+	FlagRemoveQuery:               removeQuery,
 	FlagSortQuery:                 sortQuery,
 	FlagDecodeDWORDHost:           decodeDWORDHost,
 	FlagDecodeOctalHost:           decodeOctalHost,
@@ -275,6 +279,10 @@ func addWWW(u *url.URL) {
 	if len(u.Host) > 0 && !strings.HasPrefix(strings.ToLower(u.Host), "www.") {
 		u.Host = "www." + u.Host
 	}
+}
+
+func removeQuery(u *url.URL) {
+	u.RawQuery = ""
 }
 
 func sortQuery(u *url.URL) {

--- a/purell_test.go
+++ b/purell_test.go
@@ -213,6 +213,13 @@ var (
 			false,
 		},
 		&testCase{
+			"RemoveQuery",
+			"http://root/toto/?b=4&a=1&c=3&b=2&a=5",
+			FlagRemoveQuery,
+			"http://root/toto/",
+			false,
+		},
+		&testCase{
 			"SortQuery",
 			"http://root/toto/?b=4&a=1&c=3&b=2&a=5",
 			FlagSortQuery,


### PR DESCRIPTION
I won't be at all offended if you think this flag has no place in purell, but it's one I would use almost exclusively :- )

context: I'm dealing with lots of news article URLs, and the unique part of the URL is almost always a slug, and the query used only for tracking (eg `?from=rssfeed` ). Stripping the query is always my first step when normalizing URLs for comparison.

eg (apologies for dailymail link):
`http://www.dailymail.co.uk/news/article-3656841/It-s-Democrats-end-25-hour-sit-Congress-gun-control-walk-cheering-crowd-without-vote-demanded.html?ITO=1490&ns_mchannel=rss&ns_campaign=1490`


Just one of the many frustrations when trying to decide if two URLs are referring to the same article - there are _loads_ more. Newspaper sites can commit some real atrocities when dealing with URLs!
