### PR TITLE
Added additional regex to address internal extra dots in hostnames

### DIFF
--- a/purell.go
+++ b/purell.go
@@ -86,6 +86,7 @@ var rxDWORDHost = regexp.MustCompile(`^(\d+)((?:\.+)?(?:\:\d*)?)$`)
 var rxOctalHost = regexp.MustCompile(`^(0\d*)\.(0\d*)\.(0\d*)\.(0\d*)((?:\.+)?(?:\:\d*)?)$`)
 var rxHexHost = regexp.MustCompile(`^0x([0-9A-Fa-f]+)((?:\.+)?(?:\:\d*)?)$`)
 var rxHostDots = regexp.MustCompile(`^(.+?)(:\d+)?$`)
+var rxHostInteriorDots = regexp.MustCompile(`\.+`)
 var rxEmptyPort = regexp.MustCompile(`:+$`)
 
 // Map of flags to implementation function.
@@ -368,6 +369,7 @@ func removeUnncessaryHostDots(u *url.URL) {
 				u.Host += matches[2]
 			}
 		}
+		u.Host = rxHostInteriorDots.ReplaceAllString(u.Host, ".")
 	}
 }
 

--- a/purell_test.go
+++ b/purell_test.go
@@ -487,6 +487,13 @@ var (
 			false,
 		},
 		{
+			"UnnecessaryHostDots-5",
+			"http://www..example...com/",
+			FlagsSafe | FlagRemoveUnnecessaryHostDots,
+			"http://www.example.com/",
+			false,
+		},
+		{
 			"EmptyPort-1",
 			"http://www.thedraymin.co.uk:/main/?p=308",
 			FlagsSafe | FlagRemoveEmptyPortSeparator,


### PR DESCRIPTION
I've added an additional regex to match multiple "."s and use that to replace them with a single "." in the "removeUnncessaryHostDots" function. I also added a test case to verify it's working as expected.

Fixes #36